### PR TITLE
fix: fix infinite loop in chord

### DIFF
--- a/src/core/interpreter.ts
+++ b/src/core/interpreter.ts
@@ -365,7 +365,7 @@ export function step(gameState: GameState): GameState {
 
           // Attempt to reveal adjacent hidden cells
           for (let ni = wrappedRow - 1; ni <= wrappedRow + 1; ni++) {
-            for (let nj = wrappedCol - 1; nj <= nj + 1; nj++) {
+            for (let nj = wrappedCol - 1; nj <= wrappedCol + 1; nj++) {
                 if (ni >= 0 && ni < nextGameState.revealed.length && nj >= 0 && nj < nextGameState.revealed[0].length) {
                   if (nextGameState.revealed[ni][nj] === 'hidden') {
                       const adjacentCellValue = nextGameState.field[ni][nj];


### PR DESCRIPTION
Fixing an issue where the condition in the for statement is always true due to the use of an incorrect variable.

Here is an example code where Chord is actually attempted by this interpreter.
https://github.com/dnek/mines-esolang/blob/d5694877a24f6c37a9c84a848febc683baffddc2/examples/roll-test.mines#L13