### PR TITLE
fix: fix argument order for perform(l)/(r) to match (col,row)=(p1,p0)

### DIFF
--- a/src/core/interpreter.test.ts
+++ b/src/core/interpreter.test.ts
@@ -476,4 +476,21 @@ describe('step', () => {
     }
     expect(gameState.stack).toEqual([1, 0, 2]);
   });
+
+  it('should perform p1;p0 when perform(r) is called', () => {
+    const codeString = `
+..***
+..*.*
+..***
+3,1 # push 8
+1,0 # push 2
+3;1 # perform(r): 8;2 is performed and (3,2) is flagged
+0,1
+`;
+    var gameState = parse(codeString, () => {});
+    while (!gameState.isFinished) {
+      gameState = step(gameState);
+    }
+    expect(gameState.revealed[2][3]).toBe('flagged');
+  });
 });

--- a/src/core/interpreter.ts
+++ b/src/core/interpreter.ts
@@ -332,7 +332,7 @@ export function step(gameState: GameState): GameState {
               const p1 = currentGameState.stack[currentGameState.stack.length - 2];
               const newStack = currentGameState.stack.slice(0, -2);
               const nextGameState = { ...currentGameState, stack: newStack };
-              const performOperation: Operation = { type: 'leftClick', row: p1, col: p0 };
+              const performOperation: Operation = { type: 'leftClick', col: p1, row: p0 };
               // Recursively call step with the new operation
               return step({ ...nextGameState, operations: [performOperation, ...nextGameState.operations.slice(nextGameState.opIndex)], opIndex: 0 });
             } else {
@@ -431,7 +431,7 @@ export function step(gameState: GameState): GameState {
                 const p1 = currentGameState.stack[currentGameState.stack.length - 2];
                 const newStack = currentGameState.stack.slice(0, -2);
                 const nextGameState = { ...currentGameState, stack: newStack };
-                const performOperation: Operation = { type: 'rightClick', row: p1, col: p0 };
+                const performOperation: Operation = { type: 'rightClick', col: p1, row: p0 };
                 // Recursively call step with the new operation
                 return step({ ...nextGameState, operations: [performOperation, ...nextGameState.operations.slice(nextGameState.opIndex)], opIndex: 0 });
               } else {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,8 +5,8 @@ export type Revealed = CellState[][];
 export type Field = number[][];
 
 export type Operation =
-  | { type: 'leftClick'; row: number; col: number }
-  | { type: 'rightClick'; row: number; col: number }
+  | { type: 'leftClick'; col: number; row: number }
+  | { type: 'rightClick'; col: number; row: number }
   | { type: 'toggleFlagMode' }
   | { type: 'noop' };
 


### PR DESCRIPTION
fix #6 